### PR TITLE
fix: clear ports when removed from portal

### DIFF
--- a/enricher/cache.go
+++ b/enricher/cache.go
@@ -15,10 +15,10 @@ func NewCache(api *gosdk.AdminClient, logger *slog.Logger) *Cache {
 	c := &Cache{
 		logger:      logger,
 		api:         api,
-		devices:     map[string]*admin.Switch{},
-		ports:       map[string]*admin.Port{},
-		portsByName: map[string]*admin.Port{},
-		portsByIp:   map[string]*admin.Port{},
+		devices:     switchMap{},
+		ports:       portMap{},
+		portsByName: portMap{},
+		portsByIp:   portMap{},
 	}
 
 	go func() {
@@ -31,14 +31,25 @@ func NewCache(api *gosdk.AdminClient, logger *slog.Logger) *Cache {
 	return c
 }
 
+type switchMap map[string]*admin.Switch
+type portMap map[string]*admin.Port
+
 type Cache struct {
 	sync.RWMutex
-	logger      *slog.Logger
-	api         *gosdk.AdminClient
-	devices     map[string]*admin.Switch
-	ports       map[string]*admin.Port
-	portsByName map[string]*admin.Port
-	portsByIp   map[string]*admin.Port
+	logger *slog.Logger
+	api    *gosdk.AdminClient
+
+	// devices maps switch IPv4 addresses to switches
+	devices switchMap
+
+	// ports maps port IDs to ports
+	ports portMap
+
+	// portsByName maps strings of the form switchname_portname to ports
+	portsByName portMap
+
+	// portsByIp maps strings of the form switchipv4_portname to ports
+	portsByIp portMap
 }
 
 func (c *Cache) update() {

--- a/enricher/cache.go
+++ b/enricher/cache.go
@@ -21,9 +21,13 @@ func NewCache(api *gosdk.AdminClient, logger *slog.Logger) *Cache {
 		portsByIp:   portMap{},
 	}
 
+	// update cache before returning to avoid initial scrapes being done before the cache is filled
+	c.update()
+
 	go func() {
 		ticker := time.NewTicker(5 * time.Minute)
-		for ; true; <-ticker.C {
+		for {
+			<-ticker.C
 			c.update()
 		}
 	}()

--- a/enricher/enricher.go
+++ b/enricher/enricher.go
@@ -32,6 +32,17 @@ func (e *Enricher) Enrich(target string, labels map[string]string) map[string]st
 	// strip "ix.asn.au" from target if it's there
 	target = strings.Replace(target, ".ix.asn.au", "", -1)
 
+	/*         | EXOS               | EOS
+	 * ifAlias | description-string | description
+	 *         | MBR: Acme          | port_XXXXXXX - MBR: Acme
+	 *         | AS1234 Acme        |
+	 * ifName  | 1:5                | Ethernet8/1
+	 * ifDescr | X870-32c Port 5    | Ethernet8/1
+	 *
+	 * EXOS does not appear to expose the display-string over SNMP, which is where we currently put the service ID,
+	 * so for these ports, we match the switchport names from the portal with ifName
+	 */
+
 	ifAlias := labels["ifAlias"]
 	ifName := labels["ifName"]
 	ifDescr := labels["ifDescr"]


### PR DESCRIPTION
Previously, the enricher would retain all port records even if they were no longer in the response from the portal, which would lead to cancelled ports still showing as active until snmp exporter was restarted.

This change recreates the maps on every update of portal data, so ports no longer returned by the portal stop being enriched.

This also fixes a slight race condition on startup where scrapes may be returned without enrichment while the first portal update is in progress, and adds a few comments to make the mapping easier to understand.